### PR TITLE
Resource Cards / Text Group Banner Styling

### DIFF
--- a/_includes/svg/icon-zoom.svg
+++ b/_includes/svg/icon-zoom.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 24.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 516 240" style="enable-background:new 0 0 516 240;" xml:space="preserve">
+	 viewBox="80 80 356 80" style="enable-background:new 0 0 516 240;" xml:space="preserve">
 <style type="text/css">
 	.st0-zoom{fill-rule:evenodd;clip-rule:evenodd;fill:#2D8CFF;}
 </style>

--- a/_includes/svg/outer-link.svg
+++ b/_includes/svg/outer-link.svg
@@ -1,3 +1,3 @@
-<svg class="outer-link" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg class="outer-link" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 19H5V5H12V3H5C3.89 3 3 3.9 3 5V19C3 20.1 3.89 21 5 21H19C20.1 21 21 20.1 21 19V12H19V19ZM14 3V5H17.59L7.76 14.83L9.17 16.24L19 6.41V10H21V3H14Z" fill="#FA114F"/>
 </svg>

--- a/_sass/components/toolkit.scss
+++ b/_sass/components/toolkit.scss
@@ -119,7 +119,11 @@
 .toolkit-flex-container {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
+    padding: 1.5rem;
+
+    @media #{$bp-below-mobile} {
+        justify-content: center;
+    }
 }
 
 .resource-container {
@@ -141,9 +145,9 @@
     padding-left: 0rem;
     padding-right: 0rem;
     padding-top: 0rem;
-    margin: 1.2rem;
+    margin: 1.2rem 1.3rem;
     position: relative;
-    min-width: 31rem;
+    min-width: 34rem;
     padding-bottom: 0;
 
     @media #{$bp-below-mobile} {
@@ -155,41 +159,25 @@
         margin: 1rem;
     }
 
-    @media only screen and (max-width: 800px) {
-        //flex: 1;
-        text-align: center;
-        width: 30rem;
-        height: 40rem;
-    }
-
-    @media only screen and (max-width: 500px) {
-        width: 15rem;
-        text-align: center;
-        padding: .5rem;
-    }
-
-    @media only screen and (max-width: 400px) {
-        width: 20rem;
-        height: 40rem;
-        padding: 2rem;
-    }
 }
 
 .toolkit-info-container {
-    padding: 2rem;
-    padding-bottom: 5rem;
+    padding: 1rem 2rem 5rem 2rem;
 
-    a {
+    h3 {
         font-size: 1.5rem;
-    }
-    @media only screen and (max-width: 500px) {
-        padding: 0rem;
+        margin-bottom: 3rem;
+        line-height: 1.75rem;
+
+        @media #{$bp-below-mobile} {
+            font-size: 1.4rem;
+            margin-bottom: 1.5rem;
+            line-height: 1.5rem;
+        }
     }
 
-    @media only screen and (max-width: 400px){
-        p {
-            font-size: 1rem;
-        }
+    @media #{$bp-below-mobile} {
+        padding: 2rem;
     }
 }
 
@@ -211,6 +199,7 @@
     font-size: 1.2rem;
     line-height: 1.2rem;
     text-align: left;
+    color: #FA114F;
 
     @media only screen and (max-width: 500px) {
         font-size: 1rem;
@@ -235,43 +224,28 @@
     font-style: normal;
     font-weight: normal;
     font-size: 1rem;
-    text-align: center;
+    text-align: left !important;
     line-height: 1.1rem;
     position: inherit;
 
-    @media only screen and (max-width: 800px) {
-        column-count: 1;
-        padding: 2rem;
-        text-align: center;
-    }
-
-    @media only screen and (max-width: 500px) {
-        column-count: 1;
-        padding: 1rem;
-        font-size: .7rem;
+    @media #{$bp-below-mobile} {
+        padding: 0rem !important;
     }
 }
 
 .toolkit-status-text {
     position: absolute;
-    padding-right: 1rem;
-    text-align: right;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 1.5rem;
+    font-size: 1.6rem;
     line-height: 1.2rem;
     bottom: 1rem;
-    left: 65%;
-    padding-top: 20rem;
-    padding-bottom: 0rem;
+    left: 69%;
     color: #333333;
 
-    @media only screen and (max-width: 800px) {
-        left: 35%;
-    }
-
-    @media only screen and (max-width: 600px) {
-        left: 30%;
+    @media #{$bp-below-mobile} {
+        width: fit-content !important;
+        float: right;
+        position: inherit;
+        padding: 1rem 0rem !important;
     }
 
     @media only screen and (max-width: 500px) {
@@ -291,10 +265,6 @@
     max-width: 13rem;
     max-height: 25rem;
     margin: auto;
-}
-
-.not-clickable {
-    color: $color-red;
 }
 
 .toolkit-flex-item-resource {

--- a/_sass/components/toolkit.scss
+++ b/_sass/components/toolkit.scss
@@ -116,16 +116,14 @@
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
+    padding: 1.4rem;
 
-    @media only screen and (max-width: 1150px) {
-        flex-direction: column;
-    }
 }
 
 .outer-link {
+    width: 30px;
     display: flex;
     align-self: flex-end;
-    padding: 0;
 }
 
 .toolkit-flex-item {
@@ -293,6 +291,13 @@
     padding: 1.5rem;
     margin: 1.5rem;
 
+    min-width: 33em;
+    flex-grow: 0;
+
+    @media #{$bp-below-mobile} {
+        min-width: auto;
+    }
+
     @media only screen and (max-width: 600px) {
         height: 30rem;
     }
@@ -305,14 +310,20 @@
     line-height: 1.5rem;
     text-decoration-line: underline;
     width: fit-content; //ADDED THIS LINE
+    margin-bottom: -1rem;
     /* Accent Color */
     color: #FA114F;
+
+    @media #{$bp-below-mobile} {
+        margin-bottom: .95rem;
+    }
 }
 
 .toolkit-resource-text {
     font-style: normal;
     font-weight: normal;
     font-size: 1.2rem;
+    text-align: left !important;
     
     color: #333333;
 }
@@ -327,7 +338,16 @@
     width: 164px;
     margin: auto auto;
     display: flex;
+    margin-bottom: 8rem;
+
+    @media #{$bp-below-mobile} {
+        margin-bottom: 3rem;
+    }
 }
 .svg-container svg{
-    width: 100%
+    width: 125%
+}
+
+.toolkit-button {
+    margin: 5px 0px;
 }

--- a/_sass/components/toolkit.scss
+++ b/_sass/components/toolkit.scss
@@ -144,9 +144,12 @@
 
 .resource-container {
     display: flex;
-    justify-content: center;
     flex-wrap: wrap;
     padding: 1.4rem;
+
+    @media #{$bp-below-mobile} {
+        justify-content: center;
+    }
 
 }
 

--- a/_sass/components/toolkit.scss
+++ b/_sass/components/toolkit.scss
@@ -208,7 +208,7 @@
     }
 }
 
-.section-container p {
+.toolkit-section-container p {
     margin: auto;
 }
 
@@ -225,7 +225,7 @@
     }
 }
 
-.section-container p {
+.toolkit-section-container p {
     @media only screen and (max-width: 800px) {
         width: 20rem;
         text-align: center;

--- a/_sass/components/toolkit.scss
+++ b/_sass/components/toolkit.scss
@@ -5,10 +5,11 @@
     &__text-group {
         display: flex; 
         flex-wrap: wrap; 
-        justify-content: space-between; 
+        justify-content: space-evenly; 
         padding-left: 30rem; 
         padding-right: 30rem; 
         text-align: center;
+        padding: 1.5rem 22rem;
 
         @media only screen and (max-width: 1300px){
             padding-left: 0;
@@ -25,6 +26,15 @@
         line-height: 4.3rem;
         align-items: center;
         text-align: center;
+    }
+
+    &__h3 {
+        margin-block-end: 0;
+        font-weight: 300;
+
+        @media #{$bp-below-mobile} {
+            font-size: .75rem;
+        }
     }
     
     &__p {

--- a/_sass/components/toolkit.scss
+++ b/_sass/components/toolkit.scss
@@ -2,6 +2,10 @@
     padding-top: 10rem; 
     padding-bottom: 10rem;
 
+    @media only screen and (max-width: 1200px) {
+        padding-bottom: 3rem;
+    }
+
     &__text-group {
         display: flex; 
         flex-wrap: wrap; 
@@ -42,6 +46,14 @@
         font-weight: normal;
         font-size: 1.7rem;
         line-height: 2rem;
+        max-width: 60vw;
+        margin: 3rem auto;
+        text-align: left;
+
+        @media only screen and (max-width: 1200px){
+            max-width: 70vw;
+        }
+
         @media only screen and (max-width: 400px){
             font-size: 1.1rem;
         }
@@ -54,8 +66,12 @@
 }
 
 .toolkit-svg {
-    width: 60%;
+    width: 45%;
     height: 60%;
+
+    @media only screen and (max-width: 1200px) {
+        width: 75%;
+    }
 }
 
 .toolkit-background {

--- a/_toolkitResources/github-resource.md
+++ b/_toolkitResources/github-resource.md
@@ -3,6 +3,6 @@ title: Github
 description: We use github for our project management and to streamline development.
 svg: svg/icon-github.svg
 link-svg: svg/outer-link.svg
-provider-link: 'https://github.com/hackforla'
+provider-link: 'https://github.com/'
 display: true
 ---

--- a/toolkit.html
+++ b/toolkit.html
@@ -28,7 +28,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
         {%- for item in site.guide-pages -%}
         {%- if item.status == 'active' -%}
 
-            <div class="toolkit-flex-item section-container">
+            <div class="toolkit-flex-item section-container toolkit-section-container">
             
                 {%- if item.svg -%}
                 <div class="toolkit-image-container">
@@ -52,7 +52,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
 
         {%- for item in site.guide-pages -%}
         {%- if item.status == 'coming-soon' -%}
-            <div class="toolkit-flex-item section-container">
+            <div class="toolkit-flex-item toolkit-section-container">
             
                 {%- if item.svg -%}
                 <div class="toolkit-image-container">
@@ -87,7 +87,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
             <!-- Searching through toolkitResources collection -->
             {%- for item in site.toolkitResources -%}
             {%- if item.display ==  true -%}
-            <div class="toolkit-flex-item-resource section-container">
+            <div class="toolkit-flex-item-resource toolkit-section-container">
 
                 {%- if item.svg -%}
                 <div class="svg-container">

--- a/toolkit.html
+++ b/toolkit.html
@@ -13,9 +13,9 @@ Here you can find, share, and suggest tools that are of use to the open source c
 </div>
 
 <div class="toolkit-header__text-group">
-    <h3>Development</h3>
-    <h3>Design</h3>
-    <h3>Project Management</h3>
+    <h3 class="toolkit-header__h3">Development</h3>
+    <h3 class="toolkit-header__h3">Design</h3>
+    <h3 class="toolkit-header__h3">Project Management</h3>
 </div>
 
 <div class="toolkit-background content-section">

--- a/toolkit.html
+++ b/toolkit.html
@@ -96,9 +96,9 @@ Here you can find, share, and suggest tools that are of use to the open source c
                 {%- endif -%}
 
                 {%- if item.title -%}
-                <h3 class="toolkit-resource-header"><a href="{{item.provider-link}}">{{ item.title }}</a></h3>
+                <h3 class="toolkit-resource-header"><a href="{{item.provider-link}}" target="_blank">{{ item.title }}</a></h3>
                 <p class="toolkit-resource-text">{{ item.description }}</p>
-                <a href="{{item.provider-link}}" class="outer-link" target="blank">
+                <a href="{{item.provider-link}}" class="outer-link" target="_blank">
                     {% include {{ item.link-svg }} %}
                 </a>
                 {%- endif -%}

--- a/toolkit.html
+++ b/toolkit.html
@@ -62,7 +62,7 @@ Here you can find, share, and suggest tools that are of use to the open source c
 
                 <div class="toolkit-info-container">
                     {%- if item.title -%}
-                    <h3 class="toolkit-flex-item-header not-clickable">{{ item.title }}</h3>
+                    <h3 class="toolkit-flex-item-header">{{ item.title }}</h3>
                     {%- endif -%}
 
                     {%- if item.description -%}


### PR DESCRIPTION
Hi Ruben, here are my styling changes for the resource cards / Grey Text Group banner thing near the top of the page. Please check them Some other files were added too, because it looks like this branch hasn't pulled from upstream recently. The extra files that are being added are to `_data/github-data.json`, `_data/vrms_data.json`, changes that happened to `_includes/current-projects.html` from a pr that Cynthia did a couple days ago, some github actions stuff, and some ballot nav stuff. Everything else should be for the toolkit page.

Please check out the incoming changes to files to double check. I think they should be ok. Also, please check out the changes visually to see if you think they are satisfying to the figma / page in general. It's not perfect, but I think they are minor enough differences to pass.

Here are some images of the changes, but I recommend checking them out on your computer to get an interactive look:
![Screenshot from 2020-09-19 15-48-31](https://user-images.githubusercontent.com/18221058/93690645-bf00f600-fa8f-11ea-86bd-e2fe50bb6532.png)
![Screenshot from 2020-09-19 15-48-39](https://user-images.githubusercontent.com/18221058/93690646-bf998c80-fa8f-11ea-922c-5f900ab6d62c.png) 
![Screenshot from 2020-09-19 15-48-49](https://user-images.githubusercontent.com/18221058/93690647-bf998c80-fa8f-11ea-84a2-cac4a98790fe.png)
![Screenshot from 2020-09-19 15-49-05](https://user-images.githubusercontent.com/18221058/93690648-c0322300-fa8f-11ea-9a54-3541dee99b95.png)
![Screenshot from 2020-09-19 15-49-12](https://user-images.githubusercontent.com/18221058/93690649-c0322300-fa8f-11ea-99e2-a36ee408333f.png)